### PR TITLE
Changed PNG writer to have correct shape

### DIFF
--- a/mritopng.py
+++ b/mritopng.py
@@ -34,7 +34,7 @@ def mri_to_png(mri_file, png_file):
         image_2d_scaled.append(row_scaled)
 
     # Writing the PNG file
-    w = png.Writer(shape[0], shape[1], greyscale=True)
+    w = png.Writer(shape[1], shape[0], greyscale=True)
     w.write(png_file, image_2d_scaled)
 
 


### PR DESCRIPTION
Changed indices of shape to actually reflect correct values for png.Writer(). When built the first time was probably only tested on square images.